### PR TITLE
Pass Format=pdf when rasterizing a PDF. Default APIServerPort to 8080 (changed in fable 2.x).

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidings",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "description": "Reporting scaffolding and pattern.",
   "main": "source/Tidings.js",
   "scripts": {

--- a/source/Tidings.js
+++ b/source/Tidings.js
@@ -38,7 +38,7 @@ const Tidings = function()
 		// This is used for rasterizers that pull the report HTML and turn the output into a pdf.
 		if (!_Fable.settings.Tidings.hasOwnProperty('TidingsServerAddress'))
 		{
-			_Fable.settings.Tidings.TidingsServerAddress = 'http://localhost:' + _Fable.settings.APIServerPort;
+			_Fable.settings.Tidings.TidingsServerAddress = `http://localhost:${_Fable.settings.APIServerPort || '8080'}`;
 		}
 
 		const libReportManifestManagement = require('./Tidings-ReportManifestManagement.js').new(_Fable);

--- a/source/behaviors/renderRasterizers/rasterizePhantom.js
+++ b/source/behaviors/renderRasterizers/rasterizePhantom.js
@@ -49,7 +49,7 @@ module.exports = (pTaskData, pState, fCallback) =>
 
 	libPhantom(
 		{
-			url: pState.Fable.settings.Tidings.TidingsServerAddress + '/1.0/Report/' + pState.Manifest.Metadata.GUIDReportDescription + '/' + tmpFileName
+			url: `${pState.Fable.settings.Tidings.TidingsServerAddress}/1.0/Report/${pState.Manifest.Metadata.GUIDReportDescription}/${tmpFileName}?Format=pdf`,
 		},
 		(pError, pPDF) =>
 		{

--- a/source/behaviors/renderRasterizers/rasterizeWKHTMLTOPDF.js
+++ b/source/behaviors/renderRasterizers/rasterizeWKHTMLTOPDF.js
@@ -79,7 +79,7 @@ module.exports = (pTaskData, pState, fCallback) =>
 	// Actually run the PDF generator (this requires the server to be running)
 	try
 	{
-		libWkhtmltopdf(pState.Fable.settings.Tidings.TidingsServerAddress + '/1.0/Report/' + pState.Manifest.Metadata.GUIDReportDescription + '/' + tmpFileName, tmpWKHTMLtoPDFSettings)
+		libWkhtmltopdf(`${pState.Fable.settings.Tidings.TidingsServerAddress}/1.0/Report/${pState.Manifest.Metadata.GUIDReportDescription}/${tmpFileName}?Format=pdf`, tmpWKHTMLtoPDFSettings)
 			.pipe(tmpOutputStream);
 	}
 	catch (pError)


### PR DESCRIPTION
I already worked around the port issue in the report service by setting this in the default config, but want to make sure nothing else breaks. Not sure if we intended fable 2.x to stop having default config, but that is the case.

The Format thing is to allow Doug to more reliably implement styling differences for "PDF view" without mutating the datum. Just passing this as a query string to the tidings Report endpoint.