### PR TITLE
Fix issue causing error messages to never be logged.

### DIFF
--- a/source/Tidings-CommonServices.js
+++ b/source/Tidings-CommonServices.js
@@ -42,10 +42,12 @@ module.exports = new function()
 			let tmpScope = null;
 			let tmpParams = null;
 			let tmpSessionID = null;
+			let tmpStack = null;
 
 			if (typeof(pError) === 'object')
 			{
-				tmpErrorMessage = pError.Message;
+				tmpErrorMessage = pError.Message || pError.message || pDefaultMessage; // don't nuke the message with nothing
+				tmpStack = pError.stack;
 				if (pError.Code)
 				{
 					tmpErrorCode = pError.Code;
@@ -67,8 +69,12 @@ module.exports = new function()
 			{
 				tmpSessionID = pRequest.UserSession.SessionID;
 			}
+			if (!tmpStack)
+			{
+				tmpStack = new Error().stack; // try to have a stack trace for debugging
+			}
 
-			_Log.warn('API Error: ' + tmpErrorMessage, {SessionID: tmpSessionID, RequestID:pRequest.RequestUUID, RequestURL:pRequest.url, Scope: tmpScope, Parameters: tmpParams, Action:'APIError'}, pRequest);
+			_Log.warn('API Error: ' + tmpErrorMessage, {SessionID: tmpSessionID, RequestID:pRequest.RequestUUID, RequestURL:pRequest.url, Scope: tmpScope, Parameters: tmpParams, Action:'APIError', Stack: tmpStack}, pRequest);
 			pResponse.send({Error:tmpErrorMessage, ErrorCode: tmpErrorCode});
 
 			return fNext();


### PR DESCRIPTION
## Issue

Calls to `sendCodedError` consistently pass `{}` as the error object: https://github.com/stevenvelozo/tidings/blob/44442b90fcb1d0d0536da6722501de3203490d88/source/endpoints/Tidings-Endpoint-File.js#L18

This causes the error logging to obliterate the passed in message with `undefined` due to: https://github.com/stevenvelozo/tidings/blob/44442b90fcb1d0d0536da6722501de3203490d88/source/Tidings-CommonServices.js#L46-L48


## Change

Add fallbacks:
* Fallback to `message` which is what a JavaScript `Error` object will have.
* Then fallback to the passed in error message.

Also, I added logic to pull the stack trace off of `Error` objects if any, or to synthesize one otherwise. This will help with debugging.