### PR TITLE
Improve error logging (log message and stack from Error objects, and propagate these objects to the logger).

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidings",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "description": "Reporting scaffolding and pattern.",
   "main": "source/Tidings.js",
   "scripts": {

--- a/source/behaviors/Tidings-ReportRender.js
+++ b/source/behaviors/Tidings-ReportRender.js
@@ -151,7 +151,7 @@ module.exports = (pDatum, pFable, fCallback) =>
 				{
 					if (pError)
 					{
-						pState.Behaviors.stateLog(pState, 'Error writing report datum: ' + pError, true);
+						pState.Behaviors.stateLog(pState, 'Error writing report datum: ' + pError, pError);
 						return fStageComplete(pError, pState);
 					}
 					pState.Behaviors.stateLog(pState, '...persisted the Report Datum');
@@ -173,7 +173,7 @@ module.exports = (pDatum, pFable, fCallback) =>
 					{
 						if (pError)
 						{
-							pState.Behaviors.stateLog(pState, 'Error loading report definition: ' + pError, true);
+							pState.Behaviors.stateLog(pState, 'Error loading report definition: ' + pError, pError);
 							return fStageComplete(pError, pState);
 						}
 						pState.Behaviors.stateLog(pState, 'Loaded definition: ' + pState.Fable.settings.Tidings.ReportDefinitionFolder + pState.Manifest.Metadata.Type);
@@ -198,7 +198,7 @@ module.exports = (pDatum, pFable, fCallback) =>
 						{
 							if (pError)
 							{
-								pState.Behaviors.stateLog(pState, 'Error loading the default report definition: ' + pError, true);
+								pState.Behaviors.stateLog(pState, 'Error loading the default report definition: ' + pError, pError);
 								return fStageComplete(pError, pState);
 							}
 							pState.Behaviors.stateLog(pState, 'Default definition loaded: ' + __dirname + '/../../reports/default');
@@ -228,14 +228,14 @@ module.exports = (pDatum, pFable, fCallback) =>
 					{
 						if (pError)
 						{
-							pState.Behaviors.stateLog(pState, 'Error loading the report behaviors. ' + pError, true);
+							pState.Behaviors.stateLog(pState, 'Error loading the report behaviors. ' + pError, pError);
 							return fStageComplete(pError, pState);
 						}
 						try
 						{
 							pState.ReportBehaviors = pState.Fable.Tidings.libraries.Underscore.extend({}, require(__dirname + '/../../tidings-report-prototype/source/Tidings-Report-Prototype.js'), require(pState.Manifest.Metadata.Locations.ReportDefinition + '/report.js'));
 						}
-						catch(pRequireError)
+						catch (pRequireError)
 						{
 							return fStageComplete(pRequireError, pState);
 						}
@@ -394,7 +394,7 @@ module.exports = (pDatum, pFable, fCallback) =>
 					{
 						if (pError)
 						{
-							pState.Behaviors.stateLog(pState, 'Error deleting scratch files', true);
+							pState.Behaviors.stateLog(pState, 'Error deleting scratch files', pError);
 						}
 
 						fStageComplete(null, pState);
@@ -410,7 +410,7 @@ module.exports = (pDatum, pFable, fCallback) =>
 
 			if (pError)
 			{
-				pState.Behaviors.stateLog(pState, 'Error rendering a tidings report: ' + pError, true);
+				pState.Behaviors.stateLog(pState, 'Error rendering a tidings report: ' + pError, pError);
 				return tmpCallback(pError, pState);
 			}
 

--- a/source/behaviors/renderBehaviors/deleteAssets.js
+++ b/source/behaviors/renderBehaviors/deleteAssets.js
@@ -15,7 +15,7 @@ module.exports = (pState, fCallback) =>
 		{
 			if (pError)
 			{
-				pState.Behaviors.stateLog(pState, 'Error deleting asset files', true);
+				pState.Behaviors.stateLog(pState, 'Error deleting asset files', pError);
 			}
 
 			fCallback(null, pState);

--- a/source/behaviors/renderBehaviors/downloadAsset.js
+++ b/source/behaviors/renderBehaviors/downloadAsset.js
@@ -24,12 +24,12 @@ module.exports = (pTaskData, pState, fCallback) =>
 			// We shouldn't bail out because one asset didn't download so don't alter the callback.
 			if (pRequestError)
 			{
-				pState.Behaviors.stateLog(pState, 'Error downloading asset: ' + JSON.stringify(pTaskData) + ' ' + pRequestError, true);
+				pState.Behaviors.stateLog(pState, 'Error downloading asset: ' + JSON.stringify(pTaskData) + ' ' + pRequestError, pRequestError);
 				return fCallback();
 			}
 			if (typeof(pBody) === 'undefined')
 			{
-				pState.Behaviors.stateLog(pState, 'Error downloading asset: ' + JSON.stringify(pTaskData) + ' ... body is undefined!', true);
+				pState.Behaviors.stateLog(pState, 'Error downloading asset: ' + JSON.stringify(pTaskData) + ' ... body is undefined!', new Error('Asset response body is undefined.'));
 				return fCallback();
 			}
 			console.log('content-type:', pResponse.headers['content-type']);

--- a/source/behaviors/renderBehaviors/explodeTemplateFiles.js
+++ b/source/behaviors/renderBehaviors/explodeTemplateFiles.js
@@ -18,13 +18,13 @@ const recurseFiles = (pPath, pState, fRecursionComplete, pPathRoot) =>
 			if (pError && pError.code == 'ENOENT')
 			{
 				pState.Behaviors.stateLog(pState, 'Warning: Template path [' + tmpNormalizedPath + '] does not exist; most likely there is no folder for the current renderer.');
-				pState.Behaviors.stateLog(pState, 'Warning FS Error Message: ' + pError);
+				pState.Behaviors.stateLog(pState, 'Warning FS Error Message: ' + pError, pError);
 				return fRecursionComplete();
 			}
 			else if (pError)
 			{
 				pState.Behaviors.stateLog(pState, 'Error: Template scanning of path [' + tmpNormalizedPath + '] failed.');
-				pState.Behaviors.stateLog(pState, 'FS Error Message: ' + pError);
+				pState.Behaviors.stateLog(pState, 'FS Error Message: ' + pError, pError);
 				return fRecursionComplete();
 			}
 

--- a/source/behaviors/renderBehaviors/getReportFileStream.js
+++ b/source/behaviors/renderBehaviors/getReportFileStream.js
@@ -22,7 +22,7 @@ module.exports = (pState, pData, pPath, pFileName, fCallback) =>
 			// We shouldn't bail out because one template didn't load so don't alter the callback.
 			if (pCreateError)
 			{
-				pState.Behaviors.stateLog(pState, 'Error making folder for report file stream: ' + pState.Behaviors.parseReportPath(pPath, pState) + ' -> ' + pFileName + ': ' + pCreateError, true);
+				pState.Behaviors.stateLog(pState, 'Error making folder for report file stream: ' + pState.Behaviors.parseReportPath(pPath, pState) + ' -> ' + pFileName + ': ' + pCreateError, pCreateError);
 			}
 
 			const tmpReportFileStream = libFS.createWriteStream(pState.Behaviors.parseReportPath(pPath, pState) + pFileName);

--- a/source/behaviors/renderBehaviors/loadReportFile.js
+++ b/source/behaviors/renderBehaviors/loadReportFile.js
@@ -15,7 +15,7 @@ module.exports = (pState, pPath, pFileName, fCallback) =>
 		{
 			if (pError)
 			{
-				pState.Behaviors.stateLog(pState, 'Error loading file: ' + JSON.stringify(pPath) + ' ' + JSON.stringify(pFileName) + ' ' + pError, true);
+				pState.Behaviors.stateLog(pState, 'Error loading file: ' + JSON.stringify(pPath) + ' ' + JSON.stringify(pFileName) + ' ' + pError, pError);
 				return fCallback(pError);
 			}
 

--- a/source/behaviors/renderBehaviors/manifestLog.js
+++ b/source/behaviors/renderBehaviors/manifestLog.js
@@ -5,7 +5,7 @@
 */
 
 // Log something to the manifest (not fable though)
-module.exports = (pManifest, pLogEntry, pIsError) =>
+module.exports = (pManifest, pLogEntry, pError) =>
 {
 	pManifest.Log.push(new Date().toUTCString() + ': ' + pLogEntry);
 };

--- a/source/behaviors/renderBehaviors/processRasterizationTask.js
+++ b/source/behaviors/renderBehaviors/processRasterizationTask.js
@@ -69,7 +69,7 @@ module.exports = (pTaskData, pState, fCallback) =>
 				pTaskData.TotalRasterizeTime = pTaskData.RasterizeEndTime - pTaskData.RasterizeStartTime;
 				if (pError)
 				{
-					pState.Behaviors.stateLog(pState, 'Error executing auto rasterizer [' + pTaskData.Rasterizer + ']: ' + pError, true);
+					pState.Behaviors.stateLog(pState, 'Error executing auto rasterizer [' + pTaskData.Rasterizer + ']: ' + pError, pError);
 					return fCallback(null, pState);
 				}
 
@@ -78,7 +78,7 @@ module.exports = (pTaskData, pState, fCallback) =>
 	}
 	catch (pError)
 	{
-		pState.Behaviors.stateLog(pState, 'Error loading auto rasterizer [' + pTaskData.Rasterizer + ']: ' + pError, true);
+		pState.Behaviors.stateLog(pState, 'Error loading auto rasterizer [' + pTaskData.Rasterizer + ']: ' + pError, pError);
 		fCallback(null, pState);
 	}
 };

--- a/source/behaviors/renderBehaviors/processReportTemplateFile.js
+++ b/source/behaviors/renderBehaviors/processReportTemplateFile.js
@@ -31,7 +31,7 @@ module.exports = (pTaskData, pState, fCallback) =>
 				{
 					debugger;
 				}
-				pState.Behaviors.stateLog(pState, 'Error loading template: ' + JSON.stringify(pTaskData) + ' ' + pReadError, true);
+				pState.Behaviors.stateLog(pState, 'Error loading template: ' + JSON.stringify(pTaskData) + ' ' + pReadError, pReadError);
 				return fCallback();
 			}
 			// Function to safely execute underscore templates
@@ -47,7 +47,7 @@ module.exports = (pTaskData, pState, fCallback) =>
 				catch (pTemplateParsingError)
 				{
 					// Uh-oh!  The user has an error in their template.
-					pState.Behaviors.stateLog(pState, 'Error parsing template: ' + pTemplateParsingError, true);
+					pState.Behaviors.stateLog(pState, 'Error parsing template: ' + pTemplateParsingError, pTemplateParsingError);
 					if (pState.Fable.settings.TidingsDebug)
 					{
 						debugger;
@@ -74,7 +74,7 @@ module.exports = (pTaskData, pState, fCallback) =>
 				{
 					// Uh-oh!  The user has an error executing their template.  Most likely it expects data in the datum that doesn't exist.
 					if (pState.Fable.TidingsDebug) debugger;
-					pState.Behaviors.stateLog(pState, 'Error executing template: ' + pTemplateExecutionError, true);
+					pState.Behaviors.stateLog(pState, 'Error executing template: ' + pTemplateExecutionError, pTemplateExecutionError);
 				}
 
 				return tmpContent;

--- a/source/behaviors/renderBehaviors/saveReportFile.js
+++ b/source/behaviors/renderBehaviors/saveReportFile.js
@@ -20,10 +20,12 @@ module.exports = (pState, pData, pPath, pFileName, fCallback) =>
 			// We shouldn't bail out because one template didn't load so don't alter the callback.
 			if (pPersistError)
 			{
-				pState.Behaviors.stateLog(pState, 'Error writing report file: ' + pState.Behaviors.parseReportPath(pPath, pState) + ' -> ' + pFileName + ': ' + pPersistError, true);
+				pState.Behaviors.stateLog(pState, 'Error writing report file: ' + pState.Behaviors.parseReportPath(pPath, pState) + ' -> ' + pFileName + ': ' + pPersistError, pPersistError);
 			}
-
-			pState.Behaviors.stateLog(pState, '--> Wrote report file: ' + pFileName + ' TO ' + pState.Behaviors.parseReportPath(pPath, pState));
+			else
+			{
+				pState.Behaviors.stateLog(pState, '--> Wrote report file: ' + pFileName + ' TO ' + pState.Behaviors.parseReportPath(pPath, pState));
+			}
 			return fCallback();
 		});
 };

--- a/source/behaviors/renderBehaviors/stateLog.js
+++ b/source/behaviors/renderBehaviors/stateLog.js
@@ -5,13 +5,27 @@
 */
 
 // Log something to the manifest with the state passed in
-module.exports = (pState, pLogEntry, pIsError) =>
+module.exports = (pState, pLogEntry, pError) =>
 {
 	pState.Manifest.Log.push(new Date().toUTCString() + ': ' + pLogEntry);
 
-	if (pIsError)
+	if (pError)
 	{
-		pState.Fable.log.error(pLogEntry);
+		let payload;
+
+		if (typeof(pError) === 'object')
+		{
+			payload = { Error: pError.message, Stack: pError.stack };
+		}
+		else if (typeof(pError) === 'string')
+		{
+			payload = { Error: pError };
+		}
+		else if (typeof(pError) !== 'boolean') // true just means "log an as error", as before - we don't except other types here, so log more for debugging
+		{
+			payload = { Error: JSON.stringify(pError), ErrorType: typeof(pError) };
+		}
+		pState.Fable.log.error(pLogEntry, payload);
 	}
 	else
 	{

--- a/source/behaviors/renderRasterizers/rasterizeCommandLine.js
+++ b/source/behaviors/renderRasterizers/rasterizeCommandLine.js
@@ -45,7 +45,7 @@ module.exports = (pTaskData, pState, fCallback) =>
 		{
 			if (pError)
 			{
-				pState.Behaviors.stateLog(pState, 'Error executing command line program: ' + JSON.stringify(pTaskData) + ' ' + pError, true);
+				pState.Behaviors.stateLog(pState, 'Error executing command line program: ' + JSON.stringify(pTaskData) + ' ' + pError, pError);
 			}
 
 			pState.Behaviors.stateLog(pState, 'STDOUT: ' + pStdout, true);

--- a/source/behaviors/renderRasterizers/rasterizeFFMPEG.js
+++ b/source/behaviors/renderRasterizers/rasterizeFFMPEG.js
@@ -48,7 +48,7 @@ module.exports = (pTaskData, pState, fCallback) =>
 		})
 		.on('error', (pError) =>
 		{
-			pState.Behaviors.stateLog(pState, 'Error executing FFMPEG ' + JSON.stringify(pTaskData) + ': ' + pError, true);
+			pState.Behaviors.stateLog(pState, 'Error executing FFMPEG ' + JSON.stringify(pTaskData) + ': ' + pError, pError);
 		})
 		.on('end', () =>
 		{

--- a/source/behaviors/renderRasterizers/rasterizePhantom.js
+++ b/source/behaviors/renderRasterizers/rasterizePhantom.js
@@ -42,7 +42,7 @@ module.exports = (pTaskData, pState, fCallback) =>
 	tmpOutputStream.on('error',
 		(pError) =>
 		{
-			pState.Behaviors.stateLog(pState, 'Error generating pdf with PhantomPDF: ' + JSON.stringify(pTaskData) + ' ' + pError, true);
+			pState.Behaviors.stateLog(pState, 'Error generating pdf with PhantomPDF: ' + JSON.stringify(pTaskData) + ' ' + pError, pError);
 			fCallback(null, pState);
 		}
 	);

--- a/source/behaviors/renderRasterizers/rasterizeWKHTMLTOPDF.js
+++ b/source/behaviors/renderRasterizers/rasterizeWKHTMLTOPDF.js
@@ -59,7 +59,7 @@ module.exports = (pTaskData, pState, fCallback) =>
 	tmpOutputStream.on('error',
 		(pError) =>
 		{
-			pState.Behaviors.stateLog(pState, 'Error generating pdf with WKHTMLPDF: ' + JSON.stringify(pTaskData) + ' ' + pError, true);
+			pState.Behaviors.stateLog(pState, 'Error generating pdf with WKHTMLPDF: ' + JSON.stringify(pTaskData) + ' ' + pError, pError);
 		}
 	);
 
@@ -84,6 +84,6 @@ module.exports = (pTaskData, pState, fCallback) =>
 	}
 	catch (pError)
 	{
-		fCallback('Problem rasterizing using the WKHTMLtoPDF library: ' + pError, pState);
+		fCallback(new Error(`Problem rasterizing using the WKHTMLtoPDF library: ${pError.message}`), pState);
 	}
 };


### PR DESCRIPTION
Currently, we have an error that expresses like this in the service logs:

```json
{
  "name": "ReportService",
  "hostname": "61d56d996319",
  "pid": 27,
  "level": 50,
  "Source": "ReportService",
  "datum": {},
  "msg": "Error executing template: TypeError: Cannot read property 'length' of undefined",
  "time": "2022-06-07T17:41:41.824Z",
  "v": 0
}
```

This change will produce more detail for helping to isolate the error location - ex. from the unit tests:

```text
[2022-06-07T17:43:51.216Z] ERROR: ApplicationNameHere/3984840 on bigal-hl-linux: Error parsing template: SyntaxError: Invalid regular expression: missing / (Source=ApplicationNameHere)
    datum: {
      "Error": "Invalid regular expression: missing /",
      "Stack": "SyntaxError: Invalid regular expression: missing /\n    at new Function (<anonymous>)\n    at Function.template (/Pavia/tidings/node_modules/underscore/underscore-node-f.cjs:924:14)\n    at generateTemplatedContent (/Pavia/tidings/source/behaviors/renderBehaviors/processReportTemplateFile.js:11:55)\n    at /Pavia/tidings/source/behaviors/renderBehaviors/processReportTemplateFile.js:15:65\n    at /Pavia/tidings/node_modules/dropbag/behaviors/Dropbag-ReadFile.js:106:5\n    at FSReqCallback.readFileAfterClose [as oncomplete] (node:internal/fs/read_file_context:69:3)"
    }
```

Example from installing change locally:

```json
{
  "name": "ReportService",
  "hostname": "f51365fe38dd",
  "pid": 23,
  "level": 50,
  "Source": "ReportService",
  "datum": {
    "Error": "scope.ArrayContainsInsensitiveLabel is not a function",
    "Stack": "TypeError: scope.ArrayContainsInsensitiveLabel is not a function\n    at /Pavia/report_definitions/global/server_js/mixins/observation.pre-render-mixins.js:433:50\n    at Array.filter (<anonymous>)\n    at Object.scope.FilterObservationsByLabels (/Pavia/report_definitions/global/server_js/mixins/observation.pre-render-mixins.js:428:32)\n    at /Pavia/report_definitions/global/server_js/templates/narratives.js:52:43\n    at Function.each (/tidings/node_modules/underscore/underscore-node-f.cjs:1323:7)\n    at Object.my.buildTemplate (/Pavia/report_definitions/global/server_js/templates/narratives.js:44:5)\n    at Object.scope.GetSharedContentTemplate (/Pavia/report_definitions/global/server_js/mixins/template.pre-render-mixins.js:148:70)\n    at /Pavia/report_definitions/global/server_js/mixins/template.pre-render-mixins.js:170:35\n    at Function.each (/tidings/node_modules/underscore/underscore-node-f.cjs:1323:7)\n    at Object.scope.GetSharedContentTemplates (/Pavia/report_definitions/global/server_js/mixins/template.pre-render-mixins.js:169:11)"
  },
  "msg": "Error executing template: TypeError: scope.ArrayContainsInsensitiveLabel is not a function",
  "time": "2022-06-07T17:43:46.989Z",
  "v": 0
}
```