### PR TITLE
Don't crash on PDF rasterize error. Don't write an empty manifest.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidings",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "description": "Reporting scaffolding and pattern.",
   "main": "source/Tidings.js",
   "scripts": {

--- a/source/behaviors/Tidings-ReportRender.js
+++ b/source/behaviors/Tidings-ReportRender.js
@@ -319,7 +319,7 @@ module.exports = (pDatum, pFable, fCallback) =>
 			},
 			(pState, fStageComplete) => { pState.Behaviors.setProgressPercentage(pState, 75, falseToNull(fStageComplete)); },
 			persistManifest,
-			// : Execute the report calculate function
+			// : Execute the report explodeTemplateFiles function
 			(pState, fStageComplete) =>
 			{
 				pState.Behaviors.stateLog(pState, 'Exploding template files...');

--- a/source/behaviors/renderBehaviors/persistManifest.js
+++ b/source/behaviors/renderBehaviors/persistManifest.js
@@ -6,6 +6,11 @@
 
 module.exports = (pState, fStageComplete) =>
 {
+	if (!pState.Manifest || (typeof(pState.Manifest) == 'object' && Object.keys(pState.Manifest).length < 1))
+	{
+		pState.Behaviors.stateLog(pState, '...manifest does not exist, not writing empty manifest. ' + JSON.stringify(pState.Manifest));
+		return fStageComplete(null, pState);
+	}
 	// Persist the manifest (and separately the datum)
 	pState.Libraries.DropBag.storeFile(
 	{

--- a/source/behaviors/renderRasterizers/rasterizeWKHTMLTOPDF.js
+++ b/source/behaviors/renderRasterizers/rasterizeWKHTMLTOPDF.js
@@ -59,7 +59,7 @@ module.exports = (pTaskData, pState, fCallback) =>
 	tmpOutputStream.on('error',
 		(pError) =>
 		{
-			pState.Behaviors.stateLog(pState, 'Error generating pdf with WKHTMLPDF: ' + JSON.stringify(pTaskData) + ' ' + pError, pError);
+			pState.Behaviors.stateLog(pState, 'Error writing pdf from WKHTMLPDF: ' + JSON.stringify(pTaskData) + ' ' + pError, pError);
 		}
 	);
 
@@ -79,8 +79,14 @@ module.exports = (pTaskData, pState, fCallback) =>
 	// Actually run the PDF generator (this requires the server to be running)
 	try
 	{
-		libWkhtmltopdf(`${pState.Fable.settings.Tidings.TidingsServerAddress}/1.0/Report/${pState.Manifest.Metadata.GUIDReportDescription}/${tmpFileName}?Format=pdf`, tmpWKHTMLtoPDFSettings)
-			.pipe(tmpOutputStream);
+		const tmpPdfStream = libWkhtmltopdf(`${pState.Fable.settings.Tidings.TidingsServerAddress}/1.0/Report/${pState.Manifest.Metadata.GUIDReportDescription}/${tmpFileName}?Format=pdf`, tmpWKHTMLtoPDFSettings);
+		tmpPdfStream.on('error',
+			(pError) =>
+			{
+				pState.Behaviors.stateLog(pState, 'Error generating pdf with WKHTMLPDF: ' + JSON.stringify(pTaskData) + ' ' + (pError.message || pError), pError);
+			}
+		);
+		tmpPdfStream.pipe(tmpOutputStream);
 	}
 	catch (pError)
 	{


### PR DESCRIPTION
Three commits:

1. Add an `on('error', () => ...)` handler to the `wkhtmltopdf` library source stream. Without this, the service crashes if the command fails.
2. Add a check for the manifest being empty (we have seen cases where it is written as a zero byte file).
3. Version bump to `1.0.26`.

NOTE: I am not failing the rasterize, which is consistent with other existing code in this code path, but I am not certain that is the correct behavior.

Testing done:

1. I rasterized a report that causes the core dump. Confirmed it no longer crashes the process, just logs an error.
2. Unsure how to repro this; but, the change seems safe.

I also fixed a comment that was wrong.