### PR TITLE
Adding new rasterizer to allow rasterization via API

### DIFF
--- a/source/behaviors/renderRasterizers/rasterizeViaAPI.js
+++ b/source/behaviors/renderRasterizers/rasterizeViaAPI.js
@@ -1,0 +1,118 @@
+// ##### Part of the **[retold](https://stevenvelozo.github.io/retold/)** system
+/**
+ * @license MIT
+ * @author <steven@velozo.com>
+ */
+/*
+Allows you to rasterize the report via an API endpoint. Define the request you make using your task data property 'Request' property
+and/or use the property ViaAPIRequest on Scratch to define the request. See the "request" library for more details on what values you can use.
+ */
+const libFS = require('fs');
+const libRequest = require('request');
+
+module.exports = (pTaskData, pState, fCallback) =>
+{
+	const tmpFileName = pTaskData.File;
+
+	// If no path was supplied, use the Stage path
+	if (!pTaskData.Path)
+	{
+		pTaskData.Path = pState.Manifest.Metadata.Locations.Stage;
+	}
+
+	if (!pTaskData.OutputPath)
+	{
+		pTaskData.OutputPath = pState.Manifest.Metadata.Locations.Stage;
+	}
+
+	if (!pTaskData.Output)
+	{
+		pTaskData.Output = tmpFileName + '.pdf';
+	}
+
+	// Need to move away from libFS only ASAFP so this works with dropbag.
+	// Because these tools are external, they likely need to happen locally in scratch then upload the files that are generated.
+	// Talk to Jason about how best to manage this and for now only support FS.
+	const tmpOutputStream = libFS.createWriteStream(pTaskData.OutputPath  + pTaskData.Output);
+	tmpOutputStream.on('finish',
+		() =>
+		{
+			fCallback(null, pState);
+		}
+	);
+	tmpOutputStream.on('error',
+		(pError) =>
+		{
+			pState.Behaviors.stateLog(pState, 'Error writing pdf from ViaAPI: ' + JSON.stringify(pTaskData) + ' ' + pError, pError);
+		}
+	);
+
+	// Load settings from the scratch state if they are there (so reports can pass them in)
+	const tmpViaAPISettings = (typeof(pState.Scratch.ViaAPIRequest) !== 'undefined') ? pState.Scratch.ViaAPIRequest : {};
+
+	const request = Object.assign({}, pTaskData?.Request || {}, tmpViaAPISettings);
+	try
+	{
+		pState.Behaviors.stateLog(pState, `Generating pdf from ViaAPI using URL ${url}` + JSON.stringify(tmpViaAPISettings));
+		makeRequestWithRetry(request,
+			(pRequestError, pResponse) =>
+			{
+				if(pRequestError)
+				{
+					tmpOutputStream.close();
+					pState.Behaviors.stateLog(pState, 'Error generating pdf with ViaAPI: ' + JSON.stringify(pTaskData) + ' ' + pRequestError, pRequestError);
+					return fCallback(pRequestError, pState);
+				}
+				pResponse.on('error',
+					(pError) =>
+					{
+						pState.Behaviors.stateLog(pState, 'Error generating pdf with ViaAPI: ' + JSON.stringify(pTaskData) + ' ' + (pError.message || pError), pError);
+					}
+				);
+				pResponse.pipe(tmpOutputStream);
+			});
+	}
+	catch (pError)
+	{
+		fCallback(new Error(`Problem rasterizing using the ViaAPI library: ${pError.message}`), pState);
+	}
+};
+
+
+function makeRequestWithRetry(pOptions, fCallback)
+{
+	var maxRetries = pOptions.maxRetries || 3;
+	pOptions._retryCount = pOptions._retryCount || 0;
+	libRequest(pOptions)
+		.on('error', (error) =>
+		{
+			fCallback(error, null);
+		})
+		.on('response', (response) =>
+		{
+			if (response.statusCode === 429)
+			{
+				pOptions._retryCount++;
+
+				if(pOptions._retryCount > maxRetries)
+				{
+					return fCallback(null, response, output);
+				}
+
+				// use our header or do a retry after exp backoff or from our header depending on who tells us to wait
+				let timeoutTime = response.headers['retry-after'] ||
+					Math.min(5, pOptions._retryCount * pOptions._retryCount);
+
+				console.log('Rate limited, retrying after ' + timeoutTime + ' seconds');
+				setTimeout(() =>
+				{
+					makeRequestWithRetry(pOptions, fCallback);
+				}, timeoutTime * 1000);
+			}
+			else
+			{
+				return fCallback(null, response, null);
+			}
+		})
+}
+

--- a/source/behaviors/renderRasterizers/rasterizeViaAPI.js
+++ b/source/behaviors/renderRasterizers/rasterizeViaAPI.js
@@ -59,15 +59,17 @@ module.exports = (pTaskData, pState, fCallback) =>
 				{
 					tmpOutputStream.close();
 					pState.Behaviors.stateLog(pState, 'Error generating pdf with ViaAPI: ' + JSON.stringify(tmpRequest) + ' ' + pRequestError, pRequestError);
-					return fCallback(pRequestError, pState);
 				}
-				pResponse.on('error',
-					(pError) =>
-					{
-						pState.Behaviors.stateLog(pState, 'Error generating pdf with ViaAPI: ' + JSON.stringify(tmpRequest) + ' ' + (pError.message || pError), pError);
-					}
-				);
-				pResponse.pipe(tmpOutputStream);
+				else
+				{
+					pResponse.on('error',
+						(pError) =>
+						{
+							pState.Behaviors.stateLog(pState, 'Error generating pdf with ViaAPI: ' + JSON.stringify(tmpRequest) + ' ' + (pError.message || pError), pError);
+						}
+					);
+					pResponse.pipe(tmpOutputStream);
+				}
 			});
 	}
 	catch (pError)


### PR DESCRIPTION
New rasterizer can be accessed by using the `ViaAPI` key. For instance

```
{
	"Rasterizer": "ViaAPI",
	"Request": {
		"url": "http://kong:8080/1.0/Chrome/Render/PDF",
		"method": "POST",
		"json": {
                      "myData": true
		}
	},
	"Output": "index.pdf"
}
```

Will POST to that url with that json body. The "Request" object is the library `request` payload. This can either be defined on the Rasterization json object OR in the Scratch object like `Scratch.ViaAPIRequest = {}`.


Theres an additional feature bolted onto the `request` options which is `maxRetries` which is defaulted to 3. This causes a 429 error to result in a delay and retry. The delay is determined by the header `retry-after` from the response or an exponential backoff with a 5 second cap.