### PR TITLE
Adding fix to common file serving to allow nested file paths

### DIFF
--- a/source/endpoints/Tidings-Endpoint-CommonFile.js
+++ b/source/endpoints/Tidings-Endpoint-CommonFile.js
@@ -126,11 +126,19 @@ module.exports = (pRequest, pResponse, fNext) =>
 		return pRequest.Tidings.commonservices.sendCodedError('Error retrieving report common File: invalid Report Type', {}, pRequest, pResponse, fNext);
 	}
 
-	const tmpFileName = pRequest.params.FileName;
+	let tmpFileName = pRequest.params.FileName;
 	if ((typeof(tmpFileName) !== 'string') || (tmpFileName.length < 1))
 	{
-		// Invalid UUID
-		return pRequest.Tidings.commonservices.sendCodedError('Error retrieving report common File: invalid File Name', {}, pRequest, pResponse, fNext);
+		const partToFind = '/'+tmpReportType+'/';
+		const ix = pRequest.url.indexOf(partToFind);
+		if(ix === -1)
+		{
+			return pRequest.Tidings.commonservices.sendCodedError('Error retrieving report common File: invalid File Name', {}, pRequest, pResponse, fNext);
+		}
+
+		// Get the file name from the URL
+
+		tmpFileName = pRequest.url.substring(ix + partToFind.length);
 	}
 
 	pRequest.Tidings.commonservices.log.info('Delivering the common file ' + tmpFileName + ' for ' + tmpReportType);


### PR DESCRIPTION
Currently if you have a file in the common folder you cant have it inside another folder. For instance

```
common/
   js/
     pict.js
```

ist not accessible using `/1.0/Report/31bf7cb1-536b-45cc-bc4f-fd49a48da0ab/LADOTD-SoilsScratchpad/js/pict.js` because 1. the Restify route doesn't handle it and 2. the logic isnt there to correctly parse the file path.

Added fixes for those but not sure im happy with the solution. Would prefer to let restify tell me what the remaining path part is so the common serve file doesnt need to know about the restify route but I couldnt figure it out. This was my best attempt after 30 minutes of fiddling